### PR TITLE
Update Cloudy-V2-05.R add bracket to line 350

### DIFF
--- a/Cloudy-V2-05.R
+++ b/Cloudy-V2-05.R
@@ -347,7 +347,7 @@ cloudy <- function (drp, dVol = 0.85, sVol = 20, plots = FALSE, silent = TRUE, v
     }##Control LVL 3 END
     ##############################
     # the next few controls are skipped if a threshold is specified (we don't want it to be overruled, even if it's wrong)
-    if(is.na(threshold){
+    if(is.na(threshold)){
     ##############################
     #excessive rain can make the standard deviations go haywire
     #we build in this simple check to make sure the treshold is not placed into the positive band


### PR DESCRIPTION
A closing bracket was missing from line 350 causing the function to not load into R. 

line 350 before edit =  "if(is.na(threshold){"
line 350 after edit =     "if(is.na(threshold)){"

First error
 Error: unexpected '{' in:
"      # the next few controls are skipped if a threshold is specified (we don't want it to be overruled, even if it's wrong)
      if(is.na(threshold){"

followed by a cascade of errors as a result.